### PR TITLE
Dah/feature/status

### DIFF
--- a/Assets/02 Scripts/Contents/Status/StatusCount.cs
+++ b/Assets/02 Scripts/Contents/Status/StatusCount.cs
@@ -8,38 +8,41 @@ public class StatusCount
 
     private StatusData _data;
 
-    private float _currentValue;
-    public float Value => _currentValue;
+    [SerializeField] private StatusType _valueType;
+    [SerializeField] private float _currentValue;
+
+    public float Value
+    {
+        get => _currentValue;
+
+        set
+        {
+            _currentValue = Mathf.Clamp(value, _data.MinValue, _data.MaxValue);
+
+            OnValueChanged?.Invoke(_currentValue);
+        }
+    }
 
     public StatusCount(StatusData data)
     {
         _data = data;
 
+        _valueType = (StatusType)data.Type;
         _currentValue = data.BaseValue;
     }
 
     public void AddValue(float value)
     {
-        _currentValue += value;
-
-        _currentValue = Mathf.Clamp(_currentValue, _data.MinValue, _data.MaxValue);
-
-        OnValueChanged?.Invoke(_currentValue);
+        Value += value;
     }
 
     public void MulValue(float value)
     {
-        _currentValue *= value;
-
-        _currentValue = Mathf.Clamp(_currentValue, _data.MinValue, _data.MaxValue);
-
-        OnValueChanged?.Invoke(_currentValue);
+        Value *= value;
     }
 
     public void Reset()
     {
-        _currentValue = _data.BaseValue;
-
-        OnValueChanged?.Invoke(_currentValue);
+        Value = _data.BaseValue;
     }
 }

--- a/Assets/02 Scripts/Contents/Status/StatusCount.cs
+++ b/Assets/02 Scripts/Contents/Status/StatusCount.cs
@@ -8,8 +8,7 @@ public class StatusCount
 
     private StatusData _data;
 
-    [SerializeField] private StatusType _valueType;
-    [SerializeField] private float _currentValue;
+    private float _currentValue;
 
     public float Value
     {
@@ -27,7 +26,6 @@ public class StatusCount
     {
         _data = data;
 
-        _valueType = (StatusType)data.Type;
         _currentValue = data.BaseValue;
     }
 

--- a/Assets/02 Scripts/Contents/Status/UnitStatus.asset
+++ b/Assets/02 Scripts/Contents/Status/UnitStatus.asset
@@ -12,4 +12,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 77b47f46bab548a408eb2b598800b34a, type: 3}
   m_Name: UnitStatus
   m_EditorClassIdentifier: 
-  StatusList: []
+  StatusList:
+  - _valueType: 1
+    _currentValue: 1
+  - _valueType: 2
+    _currentValue: 1
+  - _valueType: 3
+    _currentValue: 1
+  - _valueType: 4
+    _currentValue: 1
+  - _valueType: 5
+    _currentValue: 1
+  - _valueType: 6
+    _currentValue: 1
+  - _valueType: 7
+    _currentValue: 1
+  - _valueType: 8
+    _currentValue: 1
+  - _valueType: 9
+    _currentValue: 1
+  - _valueType: 10
+    _currentValue: 1
+  - _valueType: 11
+    _currentValue: 1
+  - _valueType: 12
+    _currentValue: 1
+  - _valueType: 13
+    _currentValue: 1

--- a/Assets/02 Scripts/Contents/Status/UnitStatus.asset
+++ b/Assets/02 Scripts/Contents/Status/UnitStatus.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77b47f46bab548a408eb2b598800b34a, type: 3}
+  m_Name: UnitStatus
+  m_EditorClassIdentifier: 
+  StatusList: []

--- a/Assets/02 Scripts/Contents/Status/UnitStatus.asset.meta
+++ b/Assets/02 Scripts/Contents/Status/UnitStatus.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 05f56be9df7798a4b82bac2252619025
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/02 Scripts/Contents/Status/UnitStatus.cs
+++ b/Assets/02 Scripts/Contents/Status/UnitStatus.cs
@@ -23,9 +23,9 @@ public enum StatusType
 [CreateAssetMenu(fileName = "UnitStatus", menuName = "Status System/Status")]
 public class UnitStatus : ScriptableObject
 {
-    [SerializeField] private List<StatusCount> StatusList;
-
     private Dictionary<StatusType, StatusCount> _statusDictionary;
+
+    public IReadOnlyDictionary<StatusType, StatusCount> StatusDictionary => _statusDictionary;
 
     public void Initialize()
     {
@@ -37,8 +37,6 @@ public class UnitStatus : ScriptableObject
         {
             _statusDictionary[(StatusType)stat.Type] = new StatusCount(stat);
         }
-
-        StatusList = _statusDictionary.Values.ToList();
     }
 
     public StatusCount GetStatus(StatusType type)

--- a/Assets/02 Scripts/Contents/Status/UnitStatus.cs
+++ b/Assets/02 Scripts/Contents/Status/UnitStatus.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -21,6 +23,8 @@ public enum StatusType
 [CreateAssetMenu(fileName = "UnitStatus", menuName = "Status System/Status")]
 public class UnitStatus : ScriptableObject
 {
+    [SerializeField] private List<StatusCount> StatusList;
+
     private Dictionary<StatusType, StatusCount> _statusDictionary;
 
     public void Initialize()
@@ -33,6 +37,8 @@ public class UnitStatus : ScriptableObject
         {
             _statusDictionary[(StatusType)stat.Type] = new StatusCount(stat);
         }
+
+        StatusList = _statusDictionary.Values.ToList();
     }
 
     public StatusCount GetStatus(StatusType type)

--- a/Assets/02 Scripts/Contents/Status/UnitStatusEditor.cs
+++ b/Assets/02 Scripts/Contents/Status/UnitStatusEditor.cs
@@ -1,0 +1,38 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+
+[CustomEditor(typeof(UnitStatus))]
+public class UnitStatusEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        UnitStatus unitStatus = (UnitStatus)target;
+
+        var statusDictionary = unitStatus.StatusDictionary;
+
+        if (statusDictionary != null)
+        {
+            foreach (var kvp in statusDictionary)
+            {
+                StatusType key = kvp.Key;
+                StatusCount value = kvp.Value;
+
+                float newValue = EditorGUILayout.FloatField(key.ToString(), value.Value);
+
+                if (newValue != value.Value)
+                {
+                    value.Value = newValue;
+
+                    EditorUtility.SetDirty(unitStatus);
+                }
+            }
+        }
+        else
+        {
+            EditorGUILayout.LabelField("Status Dictionary is null or empty.");
+        }
+    }
+}

--- a/Assets/02 Scripts/Contents/Status/UnitStatusEditor.cs.meta
+++ b/Assets/02 Scripts/Contents/Status/UnitStatusEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05af83725b505894faf2278de601a5fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#4 PR과 비교하여 달라진 점

삭제
- StatusCount 값을 변경하기 위해 UnitStatus 스크립트 내에 존재했던 StatusList 삭제
- StatusCount 내부의 private 변수인 _currentValue 값 직렬화 했던 부분 삭제
- StatusCount 내부에 어떤 StatusType의 값인지 나타내기 위해 추가했던 _valueType 변수 삭제 
요약 : 깔끔해짐, private은 private으로 냅둘 수 있어서 편안함

추가
- UnitStatus 내부에 _statusDictionary를 가져오는 public IReadOnlyDictionary 타입 변수 StatusDictionary 추가 (커스텀 에디터 스크립트에서 접근할 수 있게 하기 위함)
- UnitStatus 커스텀 에디터 스크립트 작성
요약 : 커스텀 에디터 스크립트 작성으로 status값 인스펙터상에서 수정할 수 있게 함

![image](https://github.com/user-attachments/assets/2049bba5-fd71-4d53-8b1c-bc6e8d3b06d6)